### PR TITLE
Upgraded metadata format

### DIFF
--- a/data_analyses/code/recover_zooniverse_metadata.py
+++ b/data_analyses/code/recover_zooniverse_metadata.py
@@ -1,0 +1,39 @@
+import pandas as pd 
+import os 
+import sys
+import json
+
+source = sys.argv[1]
+destination = sys.argv[2]
+
+subjects = pd.read_csv('data_analyses/maturity-of-baby-sounds-subjects.csv')
+links = pd.read_csv('data_analyses/metadata/filename_links.csv')
+links.rename(columns = {'FileName': 'recording'}, inplace = True)
+
+def get_name(s):
+    try:
+        return os.path.splitext(json.loads(s)['Name'])[0]
+    except:
+        return 'NA'
+
+subjects['AudioData'] = subjects['metadata'].apply(get_name).astype(str)
+
+df = pd.read_csv(source, dtype = {'AudioData': str})
+df = df.merge(subjects, left_on = 'AudioData', right_on = 'AudioData')
+df = df.merge(links, left_on = 'ChildID', right_on = 'ChildID')
+
+df['onset'] = (df['onset']*1000).astype(int)
+df['offset'] = (df['offset']*1000).astype(int)
+
+df['onset'] = df['onset'] + 500 * df['chunk_pos']
+df['offset'] = df['onset'] + 500
+
+df['speaker_type'] = 'CHI'
+df['wav'] = 'NA'
+df['mp3'] = 'NA'
+df['date_extracted'] = 'NA'
+df['uploaded'] = True
+
+df.rename(columns = {'subject_id': 'zooniverse_id'}, inplace = True)
+
+df.to_csv(destination, index = False)

--- a/data_analyses/code/recover_zooniverse_metadata.py
+++ b/data_analyses/code/recover_zooniverse_metadata.py
@@ -2,12 +2,18 @@ import pandas as pd
 import os 
 import sys
 import json
+import argparse
 
-source = sys.argv[1]
-destination = sys.argv[2]
+parser = argparse.ArgumentParser(description = '')
+parser.add_argument('source', help = 'path to the source metadata to convert')
+parser.add_argument('destination', help = 'destination path')
+parser.add_argument('--subjects', help = 'path to the Zooniverse .csv subjects export', default = 'data_analyses/maturity-of-baby-sounds-subjects.csv')
+parser.add_argument('--links', help = 'path to the dataframe linking ChildID to FileName', default = 'data_analyses/metadata/filename_links.csv')
 
-subjects = pd.read_csv('data_analyses/maturity-of-baby-sounds-subjects.csv')
-links = pd.read_csv('data_analyses/metadata/filename_links.csv')
+args = parser.parse_args()
+
+subjects = pd.read_csv(args.subjects)
+links = pd.read_csv(args.links)
 links.rename(columns = {'FileName': 'recording'}, inplace = True)
 
 def get_name(s):
@@ -18,7 +24,7 @@ def get_name(s):
 
 subjects['AudioData'] = subjects['metadata'].apply(get_name).astype(str)
 
-df = pd.read_csv(source, dtype = {'AudioData': str})
+df = pd.read_csv(args.source, dtype = {'AudioData': str})
 df = df.merge(subjects, left_on = 'AudioData', right_on = 'AudioData')
 df = df.merge(links, left_on = 'ChildID', right_on = 'ChildID')
 
@@ -36,4 +42,4 @@ df['uploaded'] = True
 
 df.rename(columns = {'subject_id': 'zooniverse_id'}, inplace = True)
 
-df.to_csv(destination, index = False)
+df.to_csv(args.destination, index = False)


### PR DESCRIPTION
`child-project` generates metadata with more information such as zooniverse_id which identifies each subject (i.e. each chunk)

to make analyses consistent with this new format, we provide a script that converts older metadata to that new format.

Instructions:
```bash
usage: python data_analyses/code/recover_zooniverse_metadata.py [-h] [--subjects SUBJECTS]
                                      [--links LINKS]
                                      source destination

positional arguments:
  source               path to the source metadata to convert
  destination          destination path

optional arguments:
  -h, --help           show this help message and exit
  --subjects SUBJECTS  path to the Zooniverse .csv subjects export
  --links LINKS        path to the dataframe linking ChildID to FileName
```

Example:

```bash
python data_analyses/code/recover_zooniverse_metadata.py data_analyses/metadata/Metadata_batch1b_20200809.csv test.csv
```